### PR TITLE
Use tags as provider default_tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/redhat-services-prod/app-sre-tenant/er-base-terraform-main/er-base-terraform-main:0.3.8-13@sha256:a991d0835739fbed914f6433b0ce281939a4b47e65e6bdd4d994a953e50a63f6 AS base
 # keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.3.0"
+LABEL konflux.additional-tags="0.4.0"
 
 FROM base AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.8.17@sha256:e4644cb5bd56fdc2c5ea3ee0525d9d21eed1603bccd6a21f887a938be7e85be1 /uv /bin/uv

--- a/er_aws_kms/input.py
+++ b/er_aws_kms/input.py
@@ -23,7 +23,7 @@ class Kms(KmsAppInterface):
     enable_key_rotation: bool | None = None
     rotation_period_in_days: int | None = None
     multi_region: bool | None = None
-    tags: dict[str, str] | None = None
+    tags: dict[str, str] = {}
     xls_key_id: str | None = None
 
     @field_validator("key_usage", mode="before")

--- a/module/main.tf
+++ b/module/main.tf
@@ -1,5 +1,9 @@
 provider "aws" {
   region = var.region
+
+  default_tags {
+    tags = var.tags
+  }
 }
 
 resource "aws_kms_key" "this" {

--- a/module/vars.tf
+++ b/module/vars.tf
@@ -95,7 +95,7 @@ variable "multi_region" {
 variable "tags" {
   description = "Tags to assign to the KMS key"
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 variable "xls_key_id" {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-aws-kms"
-version = "0.3.0"
+version = "0.4.0"
 description = "ERv2 module for managing KMS keys"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "Apache 2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 
 [[package]]
 name = "er-aws-kms"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "external-resources-io" },


### PR DESCRIPTION
Config provider to use tags as default_tags, ensure all resources created contain same tags.

Depends on https://github.com/app-sre/qontract-reconcile/pull/5220

[APPSRE-12469](https://issues.redhat.com/browse/APPSRE-12469)